### PR TITLE
Fix refresh_token not available after sign out and signing in again

### DIFF
--- a/lib/google_sign_in_desktop.dart
+++ b/lib/google_sign_in_desktop.dart
@@ -366,11 +366,11 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
             'redirect_uri': redirectUri,
             'response_type': 'code',
             'scope': _scopes.join(' '),
-            // So that we get a refresh token every time we sign in
-            'access_type': 'offline',
             'code_challenge': codeChallenge,
             'code_challenge_method': 'S256',
             'state': state,
+            // https://developers.google.com/identity/protocols/oauth2/web-server#offline
+            'access_type': 'offline',
           },
         ),
       );

--- a/lib/google_sign_in_desktop.dart
+++ b/lib/google_sign_in_desktop.dart
@@ -366,6 +366,8 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
             'redirect_uri': redirectUri,
             'response_type': 'code',
             'scope': _scopes.join(' '),
+            // So that we get a refresh token every time we sign in
+            'access_type': 'offline',
             'code_challenge': codeChallenge,
             'code_challenge_method': 'S256',
             'state': state,

--- a/test/google_sign_in_desktop_test.dart
+++ b/test/google_sign_in_desktop_test.dart
@@ -662,6 +662,14 @@ void main() {
                   'TestState',
                 ),
               );
+
+              expect(
+                url.queryParameters,
+                containsPair(
+                  'access_type',
+                  'offline',
+                ),
+              );
             },
           );
 
@@ -871,6 +879,14 @@ void main() {
                 containsPair(
                   'state',
                   'TestState',
+                ),
+              );
+
+              expect(
+                url.queryParameters,
+                containsPair(
+                  'access_type',
+                  'offline',
                 ),
               );
             },


### PR DESCRIPTION
**Describe the change**
It configures the auth with the `offline` type. With this we make sure that after signing out and requesting a token again, we obtain a new `refresh_token`. Otherwise, we would lose until the user resets the app consent in the Google dashboard.

**Current behavior**
When signing out the token data is generally removed, so the refresh_token we've saved is lost, because signing in again won't return a `refresh_token`.

**New behavior**
By specifying `offline`, we get a refresh_token to handle locally everytime we sign in.

**Additional context**
https://developers.google.com/identity/protocols/oauth2/web-server#offline

If you are ok with the changes I'll look into the possibility of adding a test case for this, although this is basically mocked server behavior, so I'm not sure if it would really be testing anything.

---
On another side of things, thank you for sharing your desktop implementation! We are trying out the feature parity with the official mobile implementation and it looks great. I will be posting a few more PRs / issues for further discussion if you don't mind.