### PR TITLE
Implement `requestScopes` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The desktop implementation implements the following methods:
 
 | Method            |    |
 |-------------------|----|
-| `canAccessScopes` | ❌ |
+| `canAccessScopes` | ❌  |
 | `clearAuthCache`  | ✔️ |
 | `disconnect`      | ✔️ |
 | `getTokens`       | ✔️ |

--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ The desktop implementation implements the following methods:
 
 | Method            |    |
 |-------------------|----|
-| `canAccessScopes` | ❌  |
+| `canAccessScopes` | ✔️ |
 | `clearAuthCache`  | ✔️ |
 | `disconnect`      | ✔️ |
 | `getTokens`       | ✔️ |
 | `init`            | ✔️ |
 | `isSignedIn`      | ✔️ |
-| `requestScopes`   | ❌  |
+| `requestScopes`   | ✔️ |
 | `signIn`          | ✔️ |
 | `signInSilently`  | ✔️ |
 | `signOut`         | ✔️ |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The desktop implementation implements the following methods:
 
 | Method            |    |
 |-------------------|----|
-| `canAccessScopes` | ✔️ |
+| `canAccessScopes` | ❌ |
 | `clearAuthCache`  | ✔️ |
 | `disconnect`      | ✔️ |
 | `getTokens`       | ✔️ |

--- a/lib/google_sign_in_desktop.dart
+++ b/lib/google_sign_in_desktop.dart
@@ -531,10 +531,10 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
     }
   }
 
-  bool _hasGrantedAllScopes({
-    required GoogleSignInDesktopTokenData tokenData,
-    required List<String> scopes,
-  }) {
+  bool _hasGrantedAllScopes(
+    GoogleSignInDesktopTokenData tokenData,
+    List<String> scopes,
+) {
     final tokenScopes = tokenData.scopes;
     if (tokenScopes == null) {
       return false;

--- a/lib/google_sign_in_desktop.dart
+++ b/lib/google_sign_in_desktop.dart
@@ -520,24 +520,6 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
     }
   }
 
-  @override
-  Future<bool> canAccessScopes(List<String> scopes,
-      {String? accessToken}) async {
-    var tokenData = await _tokenDataStore.get();
-
-    if (tokenData == null || tokenData.accessToken != accessToken) {
-      return false;
-    }
-
-    final isTokenValid = tokenData.isExpired() == false;
-
-    return isTokenValid &&
-        _hasGrantedAllScopes(
-          queryScopes: scopes,
-          grantedScopes: tokenData.scopes!,
-        );
-  }
-
   bool _hasGrantedAllScopes({
     required List<String> queryScopes,
     required List<String> grantedScopes,

--- a/lib/google_sign_in_desktop.dart
+++ b/lib/google_sign_in_desktop.dart
@@ -482,7 +482,6 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
   }
 
   @override
-  // ignore: avoid_renaming_method_parameters
   Future<bool> requestScopes(List<String> scopes) async {
     if (scopes.isEmpty) {
       throw ArgumentError.value(

--- a/lib/google_sign_in_desktop.dart
+++ b/lib/google_sign_in_desktop.dart
@@ -502,16 +502,10 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
         tokenData = (await _signIn()).$1;
 
         // It's a fresh sign in, so directly return if the requested scopes are granted
-        return _hasGrantedAllScopes(
-          tokenData: tokenData,
-          scopes: scopes,
-        );
+        return _hasGrantedAllScopes(tokenData, scopes);
       }
 
-      if (_hasGrantedAllScopes(
-        tokenData: tokenData,
-        scopes: scopes,
-      )) {
+      if (_hasGrantedAllScopes(tokenData, scopes)) {
         return true;
       }
 
@@ -520,10 +514,7 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
       _scopes = {..._scopes, ...scopes}.toList();
       tokenData = (await _signIn()).$1;
 
-      return _hasGrantedAllScopes(
-        tokenData: tokenData,
-        scopes: scopes,
-      );
+      return _hasGrantedAllScopes(tokenData, scopes);
     } catch (_) {
       // If something goes wrong, revert the scopes back to the previous state
       _scopes = previousScopes;
@@ -534,7 +525,7 @@ class GoogleSignInDesktop extends GoogleSignInPlatform {
   bool _hasGrantedAllScopes(
     GoogleSignInDesktopTokenData tokenData,
     List<String> scopes,
-) {
+  ) {
     final tokenScopes = tokenData.scopes;
     if (tokenScopes == null) {
       return false;


### PR DESCRIPTION
**Describe the change**
Implements `requestScopes` and `canAccessScopes`.

**Current behavior**
Missing implementation

**New behavior**
`requestScopes`: It will trigger a sign in with the new scopes if not signed in. If signed in, it will check if the token data has granted the new scopes. If they have not been granted, a sign in flow is requested with the new scopes.

`canAccessScopes`: Checks the token data to see if the scopes have been granted.

Tests can be added if you are ok with this route for the implementation.


